### PR TITLE
add support for calling defineProperty on exports

### DIFF
--- a/lib/register.js
+++ b/lib/register.js
@@ -11,6 +11,9 @@ const toHook = []
 const proxyHandler = {
   set(target, name, value) {
     return setters.get(target)[name](value)
+  },
+  defineProperty(target, property, descriptor) {
+    return setters.get(target)[property](descriptor.value)
   }
 }
 

--- a/lib/register.js
+++ b/lib/register.js
@@ -12,7 +12,12 @@ const proxyHandler = {
   set(target, name, value) {
     return setters.get(target)[name](value)
   },
+
   defineProperty(target, property, descriptor) {
+    if ((!('value' in descriptor))) {
+      throw new Error('Getters/setters are not supported for exports property descriptors.')
+    }
+
     return setters.get(target)[property](descriptor.value)
   }
 }

--- a/test/hook/define-property.js
+++ b/test/hook/define-property.js
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
+
+const Hook = require('../../index.js')
+const { rejects } = require('assert')
+
+Hook((exports, name) => {
+  if (name === 'os') {
+    Object.defineProperty(exports, 'freemem', {
+      get: () => () => 47
+    })
+  }
+})
+
+;(async () => {
+  rejects(async () => {
+    await import('os')
+  })
+})()

--- a/test/hook/dynamic-import.js
+++ b/test/hook/dynamic-import.js
@@ -9,8 +9,10 @@ Hook((exports, name) => {
   if (name.match(/something\.m?js/)) {
     exports.foo += 15
   }
-  if (name.match('os')) {
-    exports.freemem = () => 47
+  if (name === 'os') {
+    Object.defineProperty(exports, 'freemem', {
+      value: () => 47
+    })
   }
 })
 

--- a/test/hook/dynamic-import.mjs
+++ b/test/hook/dynamic-import.mjs
@@ -9,8 +9,10 @@ Hook((exports, name) => {
   if (name.match(/something\.m?js/)) {
     exports.foo += 15
   }
-  if (name.match('os')) {
-    exports.freemem = () => 47
+  if (name === 'os') {
+    Object.defineProperty(exports, 'freemem', {
+      value: () => 47
+    })
   }
 })
 

--- a/test/hook/static-import.mjs
+++ b/test/hook/static-import.mjs
@@ -12,8 +12,10 @@ Hook((exports, name) => {
   if (name.match(/something\.m?js/)) {
     exports.foo += 15
   }
-  if (name.match('os')) {
-    exports.freemem = () => 47
+  if (name === 'os') {
+    Object.defineProperty(exports, 'freemem', {
+      value: () => 47
+    })
   }
 })
 

--- a/test/low-level/dynamic-import.js
+++ b/test/low-level/dynamic-import.js
@@ -9,8 +9,10 @@ addHook((name, exports) => {
   if (name.match(/something\.m?js/)) {
     exports.foo += 15
   }
-  if (name.match('os')) {
-    exports.freemem = () => 47
+  if (name === 'node:os') {
+    Object.defineProperty(exports, 'freemem', {
+      value: () => 47
+    })
   }
 })
 

--- a/test/low-level/static-import.mjs
+++ b/test/low-level/static-import.mjs
@@ -12,8 +12,10 @@ addHook((name, exports) => {
   if (name.match(/something\.m?js/)) {
     exports.foo += 15
   }
-  if (name.match('os')) {
-    exports.freemem = () => 47
+  if (name === 'node:os') {
+    Object.defineProperty(exports, 'freemem', {
+      value: () => 47
+    })
   }
 })
 


### PR DESCRIPTION
This PR adds support for calling `defineProperty` on exports to allow using `shimmer` and similar implementations. It also fixes the tests that were checking if the module name contains `os` instead of checking it's exactly `os`.