### PR TITLE
support extensionless entrypoints

### DIFF
--- a/hook.mjs
+++ b/hook.mjs
@@ -4,6 +4,10 @@
 
 const specifiers = new Map()
 
+const EXTENSION_RE = /\.(js|mjs|cjs)$/
+
+let entrypoint
+
 export async function resolve (specifier, context, parentResolve) {
   const { parentURL = '' } = context
 
@@ -11,6 +15,11 @@ export async function resolve (specifier, context, parentResolve) {
     specifier = specifier.replace('iitm:', '')
   }
   const url = await parentResolve(specifier, context, parentResolve)
+
+  if (parentURL === '' && !EXTENSION_RE.test(url.url)) {
+    entrypoint = url.url
+    return { url: url.url, format: 'commonjs' }
+  }
 
   if (parentURL === import.meta.url || parentURL.startsWith('iitm:')) {
     return url
@@ -27,6 +36,11 @@ export function getFormat (url, context, parentGetFormat) {
   if (url.startsWith('iitm:')) {
     return {
       format: 'module'
+    }
+  }
+  if (url === entrypoint) {
+    return {
+      format: 'commonjs'
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Intercept imports in Node.js",
   "main": "index.js",
   "scripts": {
-    "test": "c8 --check-coverage --lines 90 imhotap --runner test/runtest --files test/{hook,low-level}/*.*js",
-    "coverage": "c8 --reporter html imhotap --runner test/runtest --files test/{hook,low-level}/*.*js && echo '\nNow open coverage/index.html\n'"
+    "test": "c8 --check-coverage --lines 90 imhotap --runner test/runtest --files test/{hook,low-level,other}/*",
+    "coverage": "c8 --reporter html imhotap --runner test/runtest --files test/{hook,low-level,other}/* && echo '\nNow open coverage/index.html\n'"
   },
   "repository": {
     "type": "git",
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/DataDog/import-in-the-middle#readme",
   "devDependencies": {
     "c8": "^7.8.0",
-    "imhotap": "^1.1.0"
+    "imhotap": "^2.0.0"
   },
   "dependencies": {
     "module-details-from-path": "^1.0.3"

--- a/test/other/executable
+++ b/test/other/executable
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
+
+// This script doesn't actually have to do anything.

--- a/test/other/import-executable.mjs
+++ b/test/other/import-executable.mjs
@@ -1,0 +1,11 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache 2.0 License.
+//
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
+
+import { rejects } from 'assert'
+(async () => {
+  await rejects(() => import('./executable'), {
+    name: 'TypeError',
+    code: 'ERR_UNKNOWN_FILE_EXTENSION'
+  })
+})()


### PR DESCRIPTION
Roughly replicates the behaviour of stock Node.js without loaders where
extensionless entrypoints are treated as CJS.

This allows IITM to work with such tools as mocha.