### PR TITLE
Add specifier parameter on addHook

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,9 +59,10 @@ export default Hook
  * lower-level APIs `addHook` and `removeHook`.
  * @param {url} string The absolute path of the module, as a `file:` URL string.
  * @param {exported} { [string]: any } An object representing the exported
+ * @param {specifier} string The name used to import the module
  * items of a module.
  */
-export type HookFunction = (url: string, exported: Namespace) => void
+export type HookFunction = (url: string, exported: Namespace, specifier: string) => void
 
 /**
  * Adds a hook to be run on any already loaded modules and any that will be

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const {
 
 function addHook(hook) {
   importHooks.push(hook)
-  toHook.forEach(([name, namespace]) => hook(name, namespace))
+  toHook.forEach(([name, namespace]) => hook(name, namespace, specifiers.get(name)))
 }
 
 function removeHook(hook) {

--- a/lib/register.js
+++ b/lib/register.js
@@ -26,7 +26,7 @@ function register(name, namespace, set, specifier) {
   specifiers.set(name, specifier)
   setters.set(namespace, set)
   const proxy = new Proxy(namespace, proxyHandler)
-  importHooks.forEach(hook => hook(name, proxy))
+  importHooks.forEach(hook => hook(name, proxy, specifier))
   toHook.push([name, proxy])
 }
 

--- a/test/hook/dynamic-import-add-hook.mjs
+++ b/test/hook/dynamic-import-add-hook.mjs
@@ -1,0 +1,15 @@
+import { addHook } from '../../index.js'
+import { strictEqual } from 'assert'
+let specifier
+
+addHook(function (name, namespace, specifierParam ) {
+  if (name.includes('something.mjs')) {
+    specifier = specifierParam
+  }
+})
+
+strictEqual(specifier, undefined)
+const { foo } = await import('../fixtures/something.mjs')
+
+strictEqual(specifier, '../fixtures/something.mjs')
+strictEqual(foo, 42)

--- a/test/hook/dynamic-import-add-hook.mjs
+++ b/test/hook/dynamic-import-add-hook.mjs
@@ -9,7 +9,9 @@ addHook(function (name, namespace, specifierParam ) {
 })
 
 strictEqual(specifier, undefined)
-const { foo } = await import('../fixtures/something.mjs')
+;(async () => {
+  const { foo } = await import('../fixtures/something.mjs')
 
-strictEqual(specifier, '../fixtures/something.mjs')
-strictEqual(foo, 42)
+  strictEqual(specifier, '../fixtures/something.mjs')
+  strictEqual(foo, 42)
+})()

--- a/test/hook/static-import-add-hook.mjs
+++ b/test/hook/static-import-add-hook.mjs
@@ -1,0 +1,13 @@
+import { addHook } from '../../index.js'
+import {  foo  } from '../fixtures/something.mjs'
+import { strictEqual } from 'assert'
+let specifier
+
+addHook(function (name, namespace, specifierParam ) {
+  if (name.includes('something.mjs')) {
+    specifier = specifierParam
+  }
+})
+
+strictEqual(specifier, '../fixtures/something.mjs')
+strictEqual(foo, 42)

--- a/test/hook/static-import-package-add-hook.mjs
+++ b/test/hook/static-import-package-add-hook.mjs
@@ -1,0 +1,14 @@
+import { addHook } from '../../index.js'
+import { Report } from 'c8'
+import { strictEqual } from 'assert'
+let specifier
+
+addHook(function (name, namespace, specifierParam ) {
+  if (name.includes('c8/index.js')) {
+    specifier = specifierParam
+    namespace.Report = () => 42
+  }
+})
+
+strictEqual(specifier, 'c8')
+strictEqual(Report({}), 42)


### PR DESCRIPTION
## What does this PR do?
Adds an extra parameter to `addHook` callbacks with the specifier information

## Motivation
Is a userful information to know if we talking about a file or about one module, it is not the same:
```
import something from './my-file.mjs'
```
or
```
import something from 'module-name'
```