### PR TITLE
Fix hook in node 16.17.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.10.0, 16.x, 17.x, 18.5.0, 18.x]
+        node-version: [12.x, 14.x, 16.10.0, 16.17.0, 16.x, 17.x, 18.5.0, 18.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 4 * * *'
 
 jobs:
   build:

--- a/hook.mjs
+++ b/hook.mjs
@@ -48,7 +48,9 @@ function addIitm (url) {
   if (NODE_MAJOR === 17) {
     return urlObj.protocol !== 'file:' ? 'file:' + urlObj.href :  urlObj.href
   }
-  return (urlObj.protocol !== 'file:' && urlObj.protocol !== 'node:') && NODE_MAJOR < 18 ? 'file:' + urlObj.href :  urlObj.href
+  return urlObj.protocol !== 'file:' && urlObj.protocol !== 'node:' && NODE_MAJOR < 18
+    ? 'file:' + urlObj.href
+    : urlObj.href
 }
 
 export async function resolve (specifier, context, parentResolve) {

--- a/hook.mjs
+++ b/hook.mjs
@@ -45,7 +45,7 @@ function deleteIitm (url) {
 function addIitm (url) {
   const urlObj = new URL(url)
   urlObj.searchParams.set('iitm', 'true')
-  return urlObj.protocol !== 'file:' && NODE_MAJOR < 18 ? 'file:' + urlObj.href :  urlObj.href
+  return (urlObj.protocol !== 'file:' && urlObj.protocol !== 'node:') && NODE_MAJOR < 18 ? 'file:' + urlObj.href :  urlObj.href
 }
 
 export async function resolve (specifier, context, parentResolve) {

--- a/hook.mjs
+++ b/hook.mjs
@@ -45,12 +45,14 @@ function deleteIitm (url) {
 function addIitm (url) {
   const urlObj = new URL(url)
   urlObj.searchParams.set('iitm', 'true')
+  if (NODE_MAJOR === 17) {
+    return urlObj.protocol !== 'file:' ? 'file:' + urlObj.href :  urlObj.href
+  }
   return (urlObj.protocol !== 'file:' && urlObj.protocol !== 'node:') && NODE_MAJOR < 18 ? 'file:' + urlObj.href :  urlObj.href
 }
 
 export async function resolve (specifier, context, parentResolve) {
   const { parentURL = '' } = context
-
   const url = await parentResolve(deleteIitm(specifier), context, parentResolve)
 
   if (parentURL === '' && !EXTENSION_RE.test(url.url)) {


### PR DESCRIPTION
`file:node:something` was a invalid url and the last node v16.17.0 version throws an error if the URL is not valid.