### PR TITLE
Fix module interception on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
       strategy:
         matrix:
-          node-version: [ 12.x, 14.x, 16.10.0, 16.17.0, 16.x, 17.x, 18.5.0, 18.x ]
+          node-version: [ 12.x, 14.x, 16.10.0, 16.17.0, 16.x, 18.5.0, 18.x ]
 
       steps:
         - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     strategy:
@@ -23,3 +22,21 @@ jobs:
       - run: npm test
       - run: npm run test:ts
         if: (matrix.node-version != '12.x' && matrix.node-version != '14.x' && matrix.node-version != '16.10.0')
+
+  build-win:
+      runs-on: windows-latest
+
+      strategy:
+        matrix:
+          node-version: [ 12.x, 14.x, 16.10.0, 16.17.0, 16.x, 17.x, 18.5.0, 18.x ]
+
+      steps:
+        - uses: actions/checkout@v2
+        - name: Use Node.js ${{ matrix.node-version }}
+          uses: actions/setup-node@v2
+          with:
+            node-version: ${{ matrix.node-version }}
+        - run: npm install
+        - run: npm run test-win
+        - run: npm run test-win:ts
+          if: (matrix.node-version != '12.x' && matrix.node-version != '14.x' && matrix.node-version != '16.10.0')

--- a/index.js
+++ b/index.js
@@ -51,7 +51,11 @@ function Hook(modules, options, hookFn) {
     if (isBuiltin) {
       name = name.replace(/^node:/, '')
     } else {
-      name = name.replace(/^file:\/\//, '')
+      if (name.startsWith('file://')) {
+        try {
+          name = fileURLToPath(name)
+        } catch (e) {}
+      }
       const details = parse(name)
       if (details) {
         name = details.name

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "test": "c8 --check-coverage --lines 90 imhotap --runner test/runtest --files test/{hook,low-level,other}/*",
+    "test-win": "c8 --check-coverage --lines 90 imhotap --runner test\\runtest.bat --files test/{hook,low-level,other}/*",
     "test:ts": "c8 imhotap --runner test/runtest --files test/typescript/*.test.mts",
+    "test-win:ts": "c8 imhotap --runner test\\runtest.bat --files test/typescript/*.test.mts",
     "coverage": "c8 --reporter html imhotap --runner test/runtest --files test/{hook,low-level,other}/* && echo '\nNow open coverage/index.html\n'"
   },
   "repository": {

--- a/test/hook/static-import-package-internals-enabled.mjs
+++ b/test/hook/static-import-package-internals-enabled.mjs
@@ -7,7 +7,7 @@ import { strictEqual } from 'assert'
 const c8Dir = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'node_modules', 'c8')
 
 Hook(['c8'], { internals: true }, (exports, name, baseDir) => {
-  strictEqual(name, 'c8/index.js')
+  strictEqual(name, path.join('c8','index.js'))
   strictEqual(baseDir, c8Dir)
   exports.Report = () => 42
 })

--- a/test/runtest
+++ b/test/runtest
@@ -6,6 +6,7 @@
 
 const { spawn } = require('child_process')
 const path = require('path')
+const url = require('url')
 
 process.env.NODE_NO_WARNINGS = 1
 
@@ -20,7 +21,7 @@ if (!filename.includes('disabled')) {
     ? path.join(__dirname, 'typescript', 'iitm-ts-node-loader.mjs')
     : path.join(__dirname, '..', 'hook.mjs')
 
-  args.unshift(`--experimental-loader=${loaderPath}`)
+  args.unshift(`--experimental-loader=${url.pathToFileURL(loaderPath)}`)
 }
 
 spawn('node', args, { stdio: 'inherit' }).on('close', code => {

--- a/test/runtest.bat
+++ b/test/runtest.bat
@@ -1,0 +1,1 @@
+node test/runtest %*


### PR DESCRIPTION
This PR fixes the bug that occurs in Windows where non-internal module loading is not intercepted due to the platform-specific path segment separator.