### PR TITLE
Extensionless support in 18.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,25 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.10.0, 16.16.0, 16.17.0, 16.x, 17.x, 18.5.0, 18.x, 20.9.0, 20.x, 21.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version:
+          - 12.x
+          - 14.x
+          - 16.10.0
+          - 16.16.0
+          - 16.17.0
+          - 16.x
+          - 17.x
+          - 18.5.0
+          - 18.18.0
+          - 18.19.0
+          - 18.x
+          - 20.9.0
+          - 20.x
+          - 21.x
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/test/other/import-executable.mjs
+++ b/test/other/import-executable.mjs
@@ -6,9 +6,10 @@ import { rejects } from 'assert'
 (async () => {
   const [processMajor, processMinor] = process.versions.node.split('.').map(Number)
   const extensionlessSupported = processMajor >= 21 ||
-    (processMajor === 20 && processMinor >= 10)
+    (processMajor === 20 && processMinor >= 10) ||
+    (processMajor === 18 && processMinor >= 19)
   if (extensionlessSupported) {
-    // Files without extension are supported in Node.js >= 20.10.0
+    // Files without extension are supported in Node.js ^21, ^20.10.0, and ^18.19.0
     return
   }
   await rejects(() => import('./executable'), {


### PR DESCRIPTION
Node.js 18.19 backported the extensionless supported added ion Node.js 21.0.0 and 20.10.0, so the test needed to be fixed for that.