### PR TITLE
Proxy default properties as well as named

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -128,6 +128,9 @@ ${exportNames.map((n) => `
 let $${n} = namespace.${n}
 export { $${n} as ${n} }
 set.${n} = (v) => {
+  if ('${n}' !== 'default' && namespace.default['${n}']) {
+    namespace.default['${n}'] = v
+  }
   $${n} = v
   return true
 }

--- a/test/fixtures/cjs-exports.js
+++ b/test/fixtures/cjs-exports.js
@@ -1,0 +1,7 @@
+'use strict'
+
+exports.add = function add(a, b) {
+  return a + b
+}
+
+exports.name = 'foo'

--- a/test/hook/static-import-aliased.mjs
+++ b/test/hook/static-import-aliased.mjs
@@ -1,0 +1,24 @@
+// The purpose of this test is to prove that CJS modules:
+// 1. Hooks apply to the added `default` export.
+// 2. Hooks apply to the "named" exports.
+
+import Hook from '../../index.js'
+import { strictEqual } from 'assert'
+import * as something from '../fixtures/cjs-exports.js'
+
+Hook((exports, name) => {
+  if (/cjs-exports\.js$/.test(name) === false) return
+  const add = exports.add
+  exports.add = function wrappedAdd(a, b) {
+    return 'wrapped: ' + add(a, b)
+  }
+
+  const namedName = exports.name
+  exports.name = `${namedName}-hooked`
+})
+
+strictEqual(something.default.add(2, 2), 'wrapped: 4')
+strictEqual(something.add(2, 2), 'wrapped: 4')
+
+strictEqual(something.default.name, 'foo-hooked')
+strictEqual(something.name, 'foo-hooked')


### PR DESCRIPTION
This PR is a follow up to a discussion in Slack. As it is, IITM hooks will easily hook a "named" export from a CJS module but extra effort is required to hook the same exports that are defined on the "default" export. Prior to this PR, the lines 20 and 23 in the included test case will fail.