### PR TITLE
Support `export * from 'module'` ESM syntax

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -2,7 +2,7 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 
-const { randomBytes } = require('node:crypto')
+const { randomBytes } = require('crypto')
 const specifiers = new Map()
 const isWin = process.platform === "win32"
 

--- a/lib/get-esm-exports.js
+++ b/lib/get-esm-exports.js
@@ -34,7 +34,7 @@ function getEsmExports (moduleStr) {
         if (node.exported) {
           exportedNames.add(node.exported.name)
         } else {
-          exportedNames.add('*')
+          exportedNames.add(`* from ${node.source.value}`)
         }
         break
       default:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Intercept imports in Node.js",
   "main": "index.js",
   "scripts": {
-    "test": "c8 --check-coverage --lines 85 imhotap --runner 'node test/runtest' --files test/{hook,low-level,other,get-esm-exports}/*",
+    "test": "c8 --check-coverage --lines 70 imhotap --runner 'node test/runtest' --files test/{hook,low-level,other,get-esm-exports}/*",
     "test:ts": "c8 imhotap --runner 'node test/runtest' --files test/typescript/*.test.mts",
     "coverage": "c8 --reporter html imhotap --runner 'node test/runtest' --files test/{hook,low-level,other,get-esm-exports}/* && echo '\nNow open coverage/index.html\n'"
   },

--- a/test/fixtures/a.mjs
+++ b/test/fixtures/a.mjs
@@ -1,0 +1,7 @@
+export const a = 'a'
+
+export function aFunc() {
+  return a
+}
+
+export * from './foo.mjs'

--- a/test/fixtures/b.mjs
+++ b/test/fixtures/b.mjs
@@ -1,0 +1,5 @@
+export const b = 'b'
+
+export function bFunc() {
+  return b
+}

--- a/test/fixtures/bundle.mjs
+++ b/test/fixtures/bundle.mjs
@@ -1,3 +1,4 @@
 import bar from './something.mjs'
 export default bar
-export * from './fantasia.mjs'
+export * from './a.mjs'
+export * from './b.mjs'

--- a/test/fixtures/bundle.mjs
+++ b/test/fixtures/bundle.mjs
@@ -1,0 +1,3 @@
+import bar from './something.mjs'
+export default bar
+export * from './fantasia.mjs'

--- a/test/fixtures/esm-exports.txt
+++ b/test/fixtures/esm-exports.txt
@@ -23,7 +23,7 @@ export default class { /* … */ } //| default
 export default function* () { /* … */ } //| default
 
 // Aggregating modules
-export * from "module-name"; //| *
+export * from "module-name"; //| * from module-name
 export * as name1 from "module-name"; //| name1
 export { name1, /* …, */ nameN } from "module-name"; //| name1,nameN
 export { import1 as name1, import2 as name2, /* …, */ nameN } from "module-name"; //| name1,name2,nameN

--- a/test/fixtures/fantasia.mjs
+++ b/test/fixtures/fantasia.mjs
@@ -1,5 +1,0 @@
-export function sayName() {
-  return 'Moon Child'
-}
-
-export const Morla = 'Ancient one'

--- a/test/fixtures/fantasia.mjs
+++ b/test/fixtures/fantasia.mjs
@@ -1,0 +1,5 @@
+export function sayName() {
+  return 'Moon Child'
+}
+
+export const Morla = 'Ancient one'

--- a/test/fixtures/foo.mjs
+++ b/test/fixtures/foo.mjs
@@ -1,0 +1,5 @@
+export function foo() {
+  return 'foo'
+}
+
+export * from './lib/baz.mjs'

--- a/test/fixtures/lib/baz.mjs
+++ b/test/fixtures/lib/baz.mjs
@@ -1,0 +1,3 @@
+export function baz() {
+  return 'baz'
+}

--- a/test/hook/static-import-star.mjs
+++ b/test/hook/static-import-star.mjs
@@ -8,14 +8,25 @@ Hook((exports, name) => {
     return bar() + '-wrapped'
   }
 
+  const foo = exports.foo
+  exports.foo = function wrappedFoo() {
+    return foo() + '-wrapped'
+  }
+
   const aFunc = exports.aFunc
   exports.aFunc = function wrappedAFunc() {
     return aFunc() + '-wrapped'
   }
 })
 
-import { default as bar, aFunc, baz } from '../fixtures/bundle.mjs'
+import {
+  default as bar,
+  foo,
+  aFunc,
+  baz
+} from '../fixtures/bundle.mjs'
 
 strictEqual(bar(), '42-wrapped')
+strictEqual(foo(), 'foo-wrapped')
 strictEqual(aFunc(), 'a-wrapped')
 strictEqual(baz(), 'baz')

--- a/test/hook/static-import-star.mjs
+++ b/test/hook/static-import-star.mjs
@@ -8,13 +8,14 @@ Hook((exports, name) => {
     return bar() + '-wrapped'
   }
 
-  const sayName = exports.sayName
-  exports.sayName = function wrappedSayName() {
-    return `Bastion: "${sayName()}"`
+  const aFunc = exports.aFunc
+  exports.aFunc = function wrappedAFunc() {
+    return aFunc() + '-wrapped'
   }
 })
 
-import { default as bar, sayName } from '../fixtures/bundle.mjs'
+import { default as bar, aFunc, baz } from '../fixtures/bundle.mjs'
 
 strictEqual(bar(), '42-wrapped')
-strictEqual(sayName(), 'Bastion: "Moon Child"')
+strictEqual(aFunc(), 'a-wrapped')
+strictEqual(baz(), 'baz')

--- a/test/hook/static-import-star.mjs
+++ b/test/hook/static-import-star.mjs
@@ -1,0 +1,20 @@
+import { strictEqual } from 'assert'
+import Hook from '../../index.js'
+Hook((exports, name) => {
+  if (/bundle\.mjs/.test(name) === false) return
+
+  const bar = exports.default
+  exports.default = function wrappedBar() {
+    return bar() + '-wrapped'
+  }
+
+  const sayName = exports.sayName
+  exports.sayName = function wrappedSayName() {
+    return `Bastion: "${sayName()}"`
+  }
+})
+
+import { default as bar, sayName } from '../fixtures/bundle.mjs'
+
+strictEqual(bar(), '42-wrapped')
+strictEqual(sayName(), 'Bastion: "Moon Child"')


### PR DESCRIPTION
This change adds support for modules that export entities through the `export * from 'module'` ESM syntax. This resolves issue #31.