### PR TITLE
Fix ESM in Node v18.19.0

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -14,7 +14,8 @@ const NODE_MINOR = Number(NODE_VERSION[1])
 
 let entrypoint
 
-if (NODE_MAJOR >= 20) {
+let getExports
+if (NODE_MAJOR >= 20 || (NODE_MAJOR == 18 && NODE_MINOR >= 19)) {
   getExports = require('./lib/get-exports.js')
 } else {
   getExports = (url) => import(url).then(Object.keys)

--- a/test/get-esm-exports/v18.19-get-esm-exports.js
+++ b/test/get-esm-exports/v18.19-get-esm-exports.js
@@ -1,0 +1,3 @@
+// v18.19.0 backported ESM hook execution to a separate thread,
+// thus being equivalent to >=v20.
+require('./v20-get-esm-exports')

--- a/test/runtest
+++ b/test/runtest
@@ -16,14 +16,19 @@ const args = [
   ...process.argv.slice(2)
 ]
 
-const [processMajor] = process.versions.node.split('.').map(Number)
+const [processMajor, processMinor] = process.versions.node.split('.').map(Number)
 
-const match = filename.match(/v([0-9]+)/)
+const match = filename.match(/v([0-9]+)(?:\.([0-9]+))?/)
 
-const versionRequirement = match ? match[1] : 0;
+const majorRequirement = match ? match[1] : 0;
+const minorRequirement = match && match?.[2];
 
-if (processMajor < versionRequirement) {
-  console.log(`skipping ${filename} as this is Node.js v${processMajor} and test wants v${versionRequirement}`);
+if (processMajor < majorRequirement && minorRequirement === undefined) {
+  console.log(`skipping ${filename} as this is Node.js v${processMajor} and test wants v${majorRequirement}`);
+  process.exit(0);
+}
+if (processMajor < majorRequirement && processMinor < minorRequirement) {
+  console.log(`skipping ${filename} as this is Node.js v${processMajor}.${processMinor} and test wants >=v${majorRequirement}.${minorRequirement}`);
   process.exit(0);
 }
 

--- a/test/runtest
+++ b/test/runtest
@@ -21,7 +21,7 @@ const [processMajor, processMinor] = process.versions.node.split('.').map(Number
 const match = filename.match(/v([0-9]+)(?:\.([0-9]+))?/)
 
 const majorRequirement = match ? match[1] : 0;
-const minorRequirement = match && match?.[2];
+const minorRequirement = match && match[2];
 
 if (processMajor < majorRequirement && minorRequirement === undefined) {
   console.log(`skipping ${filename} as this is Node.js v${processMajor} and test wants v${majorRequirement}`);


### PR DESCRIPTION
Node v18.19.0 includes a backport of ESM loading on a separate thread -- https://github.com/nodejs/node/commit/bac9b1758f36fb3504589ffc5ed610d574dca47d. This PR updates the version check to use AST parsing on Node >= 18.19.0.