### PR TITLE
chore: don't create a package-lock file

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
Would you consider a .npmrc file to not create a package-lock file?
The reason I'm suggesting it, is because I had a short bit of confusion in one of my working copies when tests were failing on the tip of "main" -- even after a `rm -rf node_modules && npm install`. My package-lock.json, which I neglected to also delete, happened to be locking some dep such that some tests failed. I didn't check at the time what deps caused it.

Totally fine if you don't want this file.