### PR TITLE
Use updated/renamed version of acorn-import-assertions (security fix)

### DIFF
--- a/lib/get-esm-exports.js
+++ b/lib/get-esm-exports.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { Parser } = require('acorn')
-const { importAssertions } = require('acorn-import-assertions')
+const { importAssertions } = require('acorn-import-attributes')
 
 const acornOpts = {
   ecmaVersion: 'latest',

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "dependencies": {
     "acorn": "^8.8.2",
-    "acorn-import-assertions": "^1.9.0",
+    "acorn-import-attributes": "^1.9.5",
     "cjs-module-lexer": "^1.2.2",
     "module-details-from-path": "^1.0.3"
   }


### PR DESCRIPTION
This dependency appears to have been renamed since 1.9.0: observe that github.com/xtuc/acorn-import-assertions redirects to https://github.com/xtuc/acorn-import-attributes.

In 1.9.2 a security vulnerability was addressed (fully qualifying a package reference to prevent a confusion attack), which is being introduced into our codebase via this repo (by way of `dd-trace`).

Validated that all current tests still pass with this update.