### PR TITLE
test: skip static-import on v22

### DIFF
--- a/test/hook/v18-static-import-assert.mjs
+++ b/test/hook/v18-static-import-assert.mjs
@@ -6,6 +6,13 @@ import Hook from '../../index.js'
 import jsonMjs from '../fixtures/json.mjs'
 import { strictEqual } from 'assert'
 
+// TODO: remove this test case when v18/v20 is EOL
+// This test fails on v22 >=
+if (process.version.startsWith('v22')) {
+  console.log('skipping v18-static-import-assert.mjs as this is Node.js v22 and test wants <= v21.x')
+  process.exit(0)
+}
+
 Hook((exports, name) => {
   if (name.match(/json\.mjs/)) {
     exports.default.data += '-dawg'


### PR DESCRIPTION
This test is making this module fail on v22 CITGM. This should give time to us to improve this test scenario for v23 >=.

Refs: https://github.com/nodejs/citgm/issues/1060