### PR TITLE
fix: Incorrect exports

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -124,7 +124,7 @@ function mapExcludingDuplicates () {
       if (map.has(k)) {
         duplicates.add(k)
         map.delete(k)
-      } else {
+      } else if (!duplicates.has(k)) {
         map.set(k, v)
       }
     },

--- a/lib/get-esm-exports.js
+++ b/lib/get-esm-exports.js
@@ -63,10 +63,10 @@ function getEsmExports ({ moduleSource, defaultAs = 'default' }) {
 
         if (node.declaration.type.toLowerCase() === 'identifier') {
           // e.g. `export default foo`
-          exportedNames.add(`rename ${node.declaration.name} as ${defaultAs}`)
-        } else {
+          exportedNames.add(node.declaration.name)
+        } else if (node.declaration && node.declaration.id && node.declaration.id.name) {
           // e.g. `export function foo () {}
-          exportedNames.add(`rename ${node.declaration.id.name} as ${defaultAs}`)
+          exportedNames.add(node.declaration.id.name)
         }
 
         break

--- a/test/fixtures/duplicate-a.mjs
+++ b/test/fixtures/duplicate-a.mjs
@@ -1,0 +1,4 @@
+export const foo = 'a'
+export default function () {
+  return 'c'
+}

--- a/test/fixtures/duplicate-b.mjs
+++ b/test/fixtures/duplicate-b.mjs
@@ -1,0 +1,1 @@
+export const foo = 'a'

--- a/test/fixtures/duplicate.mjs
+++ b/test/fixtures/duplicate.mjs
@@ -1,0 +1,5 @@
+export * from './duplicate-a.mjs'
+export * from './duplicate-b.mjs'
+
+const foo = 'foo'
+export default foo

--- a/test/fixtures/export-types/default-call-expression-renamed.mjs
+++ b/test/fixtures/export-types/default-call-expression-renamed.mjs
@@ -1,0 +1,2 @@
+export * from './default-call-expression.mjs'
+export { default as somethingElse } from './default-call-expression.mjs'

--- a/test/fixtures/export-types/default-call-expression.mjs
+++ b/test/fixtures/export-types/default-call-expression.mjs
@@ -1,0 +1,1 @@
+export default parseInt('1')

--- a/test/hook/default-export.mjs
+++ b/test/hook/default-export.mjs
@@ -12,6 +12,8 @@ import gfn from '../fixtures/export-types/default-generator.mjs'
 import afn from '../fixtures/export-types/default-function-anon.mjs'
 import acn from '../fixtures/export-types/default-class-anon.mjs'
 import agfn from '../fixtures/export-types/default-generator-anon.mjs'
+import callEx from '../fixtures/export-types/default-call-expression.mjs'
+import { somethingElse } from '../fixtures/export-types/default-call-expression-renamed.mjs'
 import defaultImportExport from '../fixtures/export-types/import-default-export.mjs'
 import varDefaultExport from '../fixtures/export-types/variable-default-export.mjs'
 import { strictEqual } from 'assert'
@@ -61,6 +63,10 @@ Hook((exports, name) => {
     exports.default = function () {
       return orig4() + 1
     }
+  } else if (name.match(/default-call-expression\.m?js/)) {
+    exports.default += 1
+  } else if (name.match(/default-call-expression-renamed\.m?js/)) {
+    exports.somethingElse += 1
   }
 })
 
@@ -76,3 +82,5 @@ strictEqual(new acn().getFoo(), 2)
 strictEqual(agfn().next().value, 2)
 strictEqual(n, 2)
 strictEqual(s, 'dogdawg')
+strictEqual(callEx, 2)
+strictEqual(somethingElse, 2)

--- a/test/hook/duplicate-exports.mjs
+++ b/test/hook/duplicate-exports.mjs
@@ -1,0 +1,19 @@
+import * as lib from '../fixtures/duplicate.mjs'
+import { notEqual, strictEqual } from 'assert'
+import Hook from '../../index.js'
+
+Hook((exports, name) => {
+  if (name.match(/duplicate\.mjs/)) {
+    // foo should not be exported because there are duplicate exports
+    strictEqual(exports.foo, undefined)
+    // default should be exported
+    strictEqual(exports.default, 'foo')
+  }
+})
+
+notEqual(lib, undefined)
+
+// foo should not be exported because there are duplicate exports
+strictEqual(lib.foo, undefined)
+// default should be exported
+strictEqual(lib.default, 'foo')

--- a/test/hook/v18.19-static-import-gotalike.mjs
+++ b/test/hook/v18.19-static-import-gotalike.mjs
@@ -3,11 +3,6 @@ import Hook from '../../index.js'
 Hook((exports, name) => {
   if (/got-alike\.mjs/.test(name) === false) return
 
-  const bar = exports.something
-  exports.something = function barWrapped () {
-    return bar() + '-wrapped'
-  }
-
   const renamedDefaultExport = exports.renamedDefaultExport
   exports.renamedDefaultExport = function bazWrapped () {
     return renamedDefaultExport() + '-wrapped'
@@ -15,21 +10,12 @@ Hook((exports, name) => {
 })
 
 /* eslint-disable import/no-named-default */
-/* eslint-disable camelcase */
 import {
   default as Got,
-  something,
-  defaultClass as DefaultClass,
-  snake_case,
   renamedDefaultExport
 } from '../fixtures/got-alike.mjs'
 
-strictEqual(something(), '42-wrapped')
 const got = new Got()
 strictEqual(got.foo, 'foo')
 
-const dc = new DefaultClass()
-strictEqual(dc.value, 'DefaultClass')
-
-strictEqual(snake_case, 'snake_case')
 strictEqual(renamedDefaultExport(), 'baz-wrapped')


### PR DESCRIPTION
Closes #68, Closes #77, Closes #62, Closes #60...

We need to mimic the behaviour of Node ESM resolution and my testing so far **without** the loader suggests that:
- `export * from` only exports named exports and we don't need to pass through default exports
- If there are duplicate named exports, none of these should be exported

Ideally we should have tests that ensure that module exports are identical both with and without the loader hook because currently this isn't the case. 

To accomplish the above:
- I've added `mapExcludingDuplicates` for `setters` which does as it suggests
- Removed auto-renaming of default exports as this doesn't appear to be what Node does (ie. #68)
- Use the export name as the Map key so we remove duplicates
- In the emitted code, only add exports to `_` if there a corresponding key in `set`. Without this, the exports passed to `Hook` don't match the final module exports