### PR TITLE
feat: Add `Hook` named export

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,5 +89,6 @@ Hook.prototype.unhook = function () {
 }
 
 module.exports = Hook
+module.exports.Hook = Hook
 module.exports.addHook = addHook
 module.exports.removeHook = removeHook

--- a/test/hook/dynamic-import.js
+++ b/test/hook/dynamic-import.js
@@ -2,7 +2,7 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 
-const Hook = require('../../index.js')
+const { Hook } = require('../../index.js')
 const { strictEqual } = require('assert')
 
 Hook((exports, name) => {

--- a/test/hook/static-import-default.mjs
+++ b/test/hook/static-import-default.mjs
@@ -2,7 +2,7 @@
 //
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 
-import Hook from '../../index.js'
+import { Hook } from '../../index.js'
 import barMjs from '../fixtures/something.mjs'
 import barJs from '../fixtures/something.js'
 import { strictEqual } from 'assert'


### PR DESCRIPTION
From [here](https://github.com/open-telemetry/opentelemetry-js/pull/4546#issue-2186767832):

> Specifically, namespace imports are required by the ESM spec to be objects. IITM's top-level export is not an object, but a callable function

Causes [issues](https://github.com/open-telemetry/opentelemetry-js/issues/4717) with some bundlers. Obviously bundled imports will not go through `import-in-the-middle` but using it should not inhibit bundlers as iitm can still hook build-in modules.

This PR adds a `Hook` named export and changes one cjs and esm test to use that new export.