### PR TITLE
1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "import-in-the-middle",
-  "version": "1.7.4",
+  "version": "1.8.0",
   "description": "Intercept imports in Node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION

$ git log --oneline --no-decorate v1.7.4..HEAD
9269d1f 1.8.0
74124e9 fix: handling of default and star exports (#85)
7fa4e9c Fix resolution of lib/register.js when using multiple loaders (#76)
e7f05ca add node 22 to test matrix (#84)
fb0e393 feat: Add `Hook` named export (#88)
bef32f2 chore: don't create a package-lock file (#67)
bf3a4fb fix: Resolve re-exports of external modules (#78)
0d9f351 fix: Handle cyclical reference to current file (#83)
1e05e4b test: skip static-import on > v21 (#81)
