### PR TITLE
fix: Named export `Hook` missing from types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ export type Options = {
   internals?: boolean
 }
 
-declare class Hook {
+export declare class Hook {
   /**
    * Creates a hook to be run on any already loaded modules and any that will
    * be loaded in the future. It will be run once per loaded module. If

--- a/test/typescript/ts-node.test.mts
+++ b/test/typescript/ts-node.test.mts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { addHook } from '../../index.js'
+import defaultHook, { Hook, addHook } from '../../index.js'
 import { sayHi } from '../fixtures/say-hi.mjs'
 
 addHook((url, exported) => {
@@ -7,5 +7,13 @@ addHook((url, exported) => {
     exported.sayHi = () => 'Hooked'
   }
 })
+
+new defaultHook((exported: any, name: string, baseDir: string|void)  => {
+
+});
+
+new Hook((exported: any, name: string, baseDir: string|void)  => {
+
+});
 
 assert.equal(sayHi('test'), 'Hooked')


### PR DESCRIPTION
In #88 I added a named `Hook` export but forgot to update the TypeScript types!