### PR TITLE
fix: `parentResolve` is not a function

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -161,6 +161,7 @@ async function processModule ({ srcUrl, context, parentGetSource, parentResolve,
         srcUrl: modUrl,
         context,
         parentGetSource,
+        parentResolve,
         excludeDefault: true
       })
       for (const [name, setter] of setters.entries()) {


### PR DESCRIPTION
Closes #99