### PR TITLE
fix: cjs resolution when falling back to `parentLoad`

### DIFF
--- a/hook.js
+++ b/hook.js
@@ -273,6 +273,8 @@ function createHook (meta) {
           parentResolve: cachedResolve
         })
         return {
+          shortCircuit: true,
+          format: 'module',
           source: `
 import { register } from '${iitmURL}'
 import * as namespace from ${JSON.stringify(realUrl)}
@@ -316,12 +318,7 @@ register(${JSON.stringify(realUrl)}, _, set, ${JSON.stringify(specifiers.get(rea
   // For Node.js 16.12.0 and higher.
   async function load (url, context, parentLoad) {
     if (hasIitm(url)) {
-      const { source } = await getSource(url, context, parentLoad)
-      return {
-        source,
-        shortCircuit: true,
-        format: 'module'
-      }
+      return getSource(url, context, parentLoad)
     }
 
     return parentLoad(url, context, parentLoad)

--- a/hook.js
+++ b/hook.js
@@ -261,7 +261,7 @@ function createHook (meta) {
     }
   }
 
-  async function getSource (url, context, parentGetSource) {
+  async function load (url, context, parentLoad) {
     if (hasIitm(url)) {
       const realUrl = deleteIitm(url)
 
@@ -269,7 +269,7 @@ function createHook (meta) {
         const setters = await processModule({
           srcUrl: realUrl,
           context,
-          parentGetSource,
+          parentGetSource: parentLoad,
           parentResolve: cachedResolve
         })
         return {
@@ -312,15 +312,6 @@ register(${JSON.stringify(realUrl)}, _, set, ${JSON.stringify(specifiers.get(rea
       }
     }
 
-    return parentGetSource(url, context, parentGetSource)
-  }
-
-  // For Node.js 16.12.0 and higher.
-  async function load (url, context, parentLoad) {
-    if (hasIitm(url)) {
-      return getSource(url, context, parentLoad)
-    }
-
     return parentLoad(url, context, parentLoad)
   }
 
@@ -330,7 +321,7 @@ register(${JSON.stringify(realUrl)}, _, set, ${JSON.stringify(specifiers.get(rea
     return {
       load,
       resolve,
-      getSource,
+      getSource: load,
       getFormat (url, context, parentGetFormat) {
         if (hasIitm(url)) {
           return {

--- a/lib/get-exports.js
+++ b/lib/get-exports.js
@@ -98,7 +98,7 @@ async function getExports (url, context, parentLoad) {
     }
 
     if (format === 'commonjs') {
-      return getCjsExports(url, context, parentLoad, source)
+      return await getCjsExports(url, context, parentLoad, source)
     }
 
     // At this point our `format` is either undefined or not known by us. Fall
@@ -109,7 +109,7 @@ async function getExports (url, context, parentLoad) {
       // isn't set at first and yet we have an ESM module with no exports.
       // I couldn't construct an example that would do this, so maybe it's
       // impossible?
-      return getCjsExports(url, context, parentLoad, source)
+      return await getCjsExports(url, context, parentLoad, source)
     }
   } catch (cause) {
     const err = new Error(`Failed to parse '${url}'`)

--- a/lib/get-exports.js
+++ b/lib/get-exports.js
@@ -92,23 +92,29 @@ async function getExports (url, context, parentLoad) {
     source = readFileSync(fileURLToPath(url), 'utf8')
   }
 
-  if (format === 'module') {
-    return getEsmExports(source)
-  }
+  try {
+    if (format === 'module') {
+      return getEsmExports(source)
+    }
 
-  if (format === 'commonjs') {
-    return getCjsExports(url, context, parentLoad, source)
-  }
+    if (format === 'commonjs') {
+      return getCjsExports(url, context, parentLoad, source)
+    }
 
-  // At this point our `format` is either undefined or not known by us. Fall
-  // back to parsing as ESM/CJS.
-  const esmExports = getEsmExports(source)
-  if (!esmExports.length) {
-    // TODO(bengl) it's might be possible to get here if somehow the format
-    // isn't set at first and yet we have an ESM module with no exports.
-    // I couldn't construct an example that would do this, so maybe it's
-    // impossible?
-    return getCjsExports(url, context, parentLoad, source)
+    // At this point our `format` is either undefined or not known by us. Fall
+    // back to parsing as ESM/CJS.
+    const esmExports = getEsmExports(source)
+    if (!esmExports.length) {
+      // TODO(bengl) it's might be possible to get here if somehow the format
+      // isn't set at first and yet we have an ESM module with no exports.
+      // I couldn't construct an example that would do this, so maybe it's
+      // impossible?
+      return getCjsExports(url, context, parentLoad, source)
+    }
+  } catch (cause) {
+    const err = new Error(`Failed to parse '${url}'`)
+    err.cause = cause
+    throw err
   }
 }
 


### PR DESCRIPTION
When falling back to `parentLoad` on parsing errors (#104), we don't consider CJS.

For CJS, the `parentLoad` can return `{ format: 'commonjs', source: undefined }`. In this case we should be passing this full result through as the result of `load()`. Once we start returning a full result from `getSource`, it becomes redundant and we can have a single `load` function.

