### PR TITLE
v1.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "import-in-the-middle",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Intercept imports in Node.js",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
$ git log --oneline --no-decorate v1.8.0..HEAD
a3497a9 v1.8.1
88605a7 fix: Fallback to `parentLoad` if parsing fails (#104)
1c6f7b0 fix: Explicitly named exports should be exported over `export *` (#103)
29f51f6 fix: CommonJs bare specifier resolution (#96)
a8b39f7 fix: `parentResolve` is not a function (#100)
c87090d fix: Named export `Hook` missing from types (#92)